### PR TITLE
Pick up only those tags starting with a 'v'

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -12,5 +12,5 @@ function sort_versions() {
     LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
 }
 
-versions=$(eval $cmd | grep -oE "tag_name\": *\".{1,15}\"," | sed 's/tag_name\": *\"v//;s/\",//' | sort_versions)
+versions=$(eval $cmd | grep -oE "tag_name\": *\"v.*.{1,15}\"," | sed 's/tag_name\": *\"v//;s/\",//' | sort_versions)
 echo $versions


### PR DESCRIPTION
## Checklist
* [ ] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description

### What's the goal of this PR?

This PR fixes the list-all command which is picking up an accidental tag which doesn't have the `v` prefix.

```sh
❯ bin/list-all | | grep "5\.10\.1"
5.10.1
"5.10.1.z'
```

This, in turn, breaks the latest-all command
```sh
❯ asdf latest --all | grep pluto
pluto	"5.10.1.z	missing
```

### What changes did you make?

Added a `v` prefix check to the grep command.